### PR TITLE
feat: Added the button in education and customizable headings

### DIFF
--- a/components/ResumeForm.tsx
+++ b/components/ResumeForm.tsx
@@ -4,9 +4,13 @@ import React from 'react';
 import { type ResumeData, type Entry } from '@/lib/initialData';
 
 // Reusable component for form sections
-const FormSection = ({ title, children }: { title: string; children: React.ReactNode }) => (
+const FormSection = ({ title, titleNode, children }: { title?: string; titleNode?: React.ReactNode; children: React.ReactNode }) => (
   <section className="mb-6">
-    <h3 className="text-base font-semibold text-gray-800 mb-3">{title}</h3>
+    {titleNode ? (
+      <div className="mb-3">{titleNode}</div>
+    ) : (
+      title && <h3 className="text-base font-semibold text-gray-800 mb-3">{title}</h3>
+    )}
     <div className="bg-white border rounded-lg shadow-sm p-4 space-y-4">
       {children}
     </div>
@@ -28,10 +32,10 @@ const Input = ({ label, name, value, onChange }: { label: string; name: string; 
   </div>
 );
 
-// --- Main Form Component ---
+//  Main Form Component 
 export const ResumeForm = ({ data, setData }: { data: ResumeData, setData: React.Dispatch<React.SetStateAction<ResumeData>> }) => {
 
-  // --- HANDLER FUNCTIONS ---
+  // HANDLER FUNCTIONS 
 
   // Handles changes for simple, top-level text fields
   const handleTextChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -72,7 +76,6 @@ export const ResumeForm = ({ data, setData }: { data: ResumeData, setData: React
     }));
   };
 
-  // --- NEW: Handlers for nested bullet points ---
   const handlePointChange = (section: 'projects' | 'experience', entryIndex: number, pointIndex: number, value: string) => {
     setData(prevData => {
       const newArray = [...prevData[section]];
@@ -101,38 +104,274 @@ export const ResumeForm = ({ data, setData }: { data: ResumeData, setData: React
     });
   };
 
+  const clearContactField = (field: keyof ResumeData['contact']) => {
+    setData(prev => ({
+      ...prev,
+      contact: {
+        ...prev.contact,
+        [field]: '',
+      },
+    }));
+  };
 
-  // --- RENDER ---
+  // Headings edit
+  const handleHeadingChange = (key: keyof ResumeData['headings'], value: string) => {
+    setData(prev => ({
+      ...prev,
+      headings: {
+        ...prev.headings,
+        [key]: value,
+      },
+    }));
+  };
+
+  // Education array handlers
+  const addEducation = () => {
+    setData(prev => ({
+      ...prev,
+      education: [...prev.education, { degree: '', university: '', details: '' }],
+    }));
+  };
+  const updateEducation = (index: number, field: 'degree' | 'university' | 'details', value: string) => {
+    setData(prev => {
+      const next = [...prev.education];
+      next[index] = { ...next[index], [field]: value } as any;
+      return { ...prev, education: next };
+    });
+  };
+  const removeEducation = (index: number) => {
+    setData(prev => ({
+      ...prev,
+      education: prev.education.filter((_, i) => i !== index),
+    }));
+  };
+
+  // Research array handlers
+  const addResearch = () => {
+    setData(prev => ({
+      ...prev,
+      research: [...prev.research, { title: '', subtitle: '', journal: '', points: [''] }],
+    }));
+  };
+  const updateResearch = (index: number, field: 'title' | 'subtitle' | 'journal', value: string) => {
+    setData(prev => {
+      const next = [...prev.research];
+      next[index] = { ...next[index], [field]: value } as any;
+      return { ...prev, research: next };
+    });
+  };
+  const updateResearchPoint = (rIndex: number, pIndex: number, value: string) => {
+    setData(prev => {
+      const next = [...prev.research];
+      const points = [...(next[rIndex].points || [])];
+      points[pIndex] = value;
+      next[rIndex] = { ...next[rIndex], points } as any;
+      return { ...prev, research: next };
+    });
+  };
+  const addResearchPoint = (rIndex: number) => {
+    setData(prev => {
+      const next = [...prev.research];
+      const points = [...(next[rIndex].points || []), ''];
+      next[rIndex] = { ...next[rIndex], points } as any;
+      return { ...prev, research: next };
+    });
+  };
+  const removeResearchPoint = (rIndex: number, pIndex: number) => {
+    setData(prev => {
+      const next = [...prev.research];
+      const points = (next[rIndex].points || []).filter((_, i) => i !== pIndex);
+      next[rIndex] = { ...next[rIndex], points } as any;
+      return { ...prev, research: next };
+    });
+  };
+  const removeResearch = (index: number) => {
+    setData(prev => ({
+      ...prev,
+      research: prev.research.filter((_, i) => i !== index),
+    }));
+  };
+
+  // Positions of Responsibility handlers (string[] with add/remove/edit)
+  const addPosition = () => {
+    setData(prev => ({
+      ...prev,
+      positions: [...prev.positions, ''],
+    }));
+  };
+  const updatePosition = (index: number, value: string) => {
+    setData(prev => {
+      const next = [...prev.positions];
+      next[index] = value;
+      return { ...prev, positions: next };
+    });
+  };
+  const removePosition = (index: number) => {
+    setData(prev => ({
+      ...prev,
+      positions: prev.positions.filter((_, i) => i !== index),
+    }));
+  };
+
+
+  // RENDER
   return (
     <div className="p-4 bg-gray-50 rounded-lg max-h-screen overflow-y-auto">
-      <FormSection title="Personal Details">
+      <FormSection
+        titleNode={(
+          <div className="flex items-end gap-3">
+            <div className="grid grid-cols-1 gap-1 flex-1">
+              <label className="text-sm font-medium text-gray-700">Personal Section Heading</label>
+              <input
+                type="text"
+                value={data.headings.personal}
+                onChange={(e) => handleHeadingChange('personal', e.target.value)}
+                className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
+              />
+              {/* TODO: This heading isn't used in the current template header; wire it up in templates if needed. */}
+            </div>
+          </div>
+        )}
+      >
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <Input label="Full Name" name="name" value={data.name} onChange={handleTextChange} />
-          <Input label="Phone" name="contact.phone" value={data.contact.phone} onChange={handleTextChange} />
-          <Input label="Email" name="contact.email" value={data.contact.email} onChange={handleTextChange} />
-          <Input label="LinkedIn" name="contact.linkedin" value={data.contact.linkedin} onChange={handleTextChange} />
-          <Input label="GitHub" name="contact.github" value={data.contact.github} onChange={handleTextChange} />
-          <Input label="Website" name="contact.website" value={data.contact.website} onChange={handleTextChange} />
-        </div>
-      </FormSection>
-
-      <FormSection title="Education">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <Input label="Degree" name="education.degree" value={data.education.degree} onChange={handleTextChange} />
-          <Input label="University" name="education.university" value={data.education.university} onChange={handleTextChange} />
-          <div className="sm:col-span-2">
-            <label className="text-sm font-medium text-gray-700">Details (GPA, Year)</label>
-            <input
-              name="education.details"
-              value={data.education.details}
-              onChange={handleTextChange}
-              className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
-            />
+          <div className="grid grid-cols-1 gap-1">
+            <label htmlFor="contact.phone" className="text-sm font-medium text-gray-700">Phone</label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                id="contact.phone"
+                name="contact.phone"
+                value={data.contact.phone}
+                onChange={handleTextChange}
+                className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-400"
+              />
+              <button type="button" onClick={() => clearContactField('phone')} className="mt-1 px-2 text-sm border rounded bg-gray-100 hover:bg-gray-200">Clear</button>
+            </div>
+          </div>
+          <div className="grid grid-cols-1 gap-1">
+            <label htmlFor="contact.email" className="text-sm font-medium text-gray-700">Email</label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                id="contact.email"
+                name="contact.email"
+                value={data.contact.email}
+                onChange={handleTextChange}
+                className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-400"
+              />
+              <button type="button" onClick={() => clearContactField('email')} className="mt-1 px-2 text-sm border rounded bg-gray-100 hover:bg-gray-200">Clear</button>
+            </div>
+          </div>
+          <div className="grid grid-cols-1 gap-1">
+            <label htmlFor="contact.linkedin" className="text-sm font-medium text-gray-700">LinkedIn</label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                id="contact.linkedin"
+                name="contact.linkedin"
+                value={data.contact.linkedin}
+                onChange={handleTextChange}
+                className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-400"
+              />
+              <button type="button" onClick={() => clearContactField('linkedin')} className="mt-1 px-2 text-sm border rounded bg-gray-100 hover:bg-gray-200">Clear</button>
+            </div>
+          </div>
+          <div className="grid grid-cols-1 gap-1">
+            <label htmlFor="contact.github" className="text-sm font-medium text-gray-700">GitHub</label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                id="contact.github"
+                name="contact.github"
+                value={data.contact.github}
+                onChange={handleTextChange}
+                className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-400"
+              />
+              <button type="button" onClick={() => clearContactField('github')} className="mt-1 px-2 text-sm border rounded bg-gray-100 hover:bg-gray-200">Clear</button>
+            </div>
+          </div>
+          <div className="grid grid-cols-1 gap-1">
+            <label htmlFor="contact.website" className="text-sm font-medium text-gray-700">Website</label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                id="contact.website"
+                name="contact.website"
+                value={data.contact.website}
+                onChange={handleTextChange}
+                className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-400"
+              />
+              <button type="button" onClick={() => clearContactField('website')} className="mt-1 px-2 text-sm border rounded bg-gray-100 hover:bg-gray-200">Clear</button>
+            </div>
           </div>
         </div>
       </FormSection>
+
+      <FormSection
+        titleNode={(
+          <div className="grid grid-cols-1 gap-1">
+            <label className="text-sm font-medium text-gray-700">{`Education Section Heading`}</label>
+            <input
+              type="text"
+              value={data.headings.education}
+              onChange={(e) => handleHeadingChange('education', e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
+            />
+          </div>
+        )}
+      >
+        <div className="space-y-4">
+          {data.education.map((edu, index) => (
+            <div key={index} className="bg-gray-50 border rounded-md p-3 relative">
+              <button onClick={() => removeEducation(index)} aria-label="Remove education" className="absolute -top-3 -right-3 text-white bg-red-500 rounded-full h-7 w-7 flex items-center justify-center shadow">×</button>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div className="grid grid-cols-1 gap-1">
+                  <label className="text-sm font-medium text-gray-700">Degree</label>
+                  <input
+                    type="text"
+                    value={edu.degree}
+                    onChange={(e) => updateEducation(index, 'degree', e.target.value)}
+                    className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
+                  />
+                </div>
+                <div className="grid grid-cols-1 gap-1">
+                  <label className="text-sm font-medium text-gray-700">University</label>
+                  <input
+                    type="text"
+                    value={edu.university}
+                    onChange={(e) => updateEducation(index, 'university', e.target.value)}
+                    className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
+                  />
+                </div>
+                <div className="sm:col-span-2">
+                  <label className="text-sm font-medium text-gray-700">Details (GPA, Year)</label>
+                  <input
+                    value={edu.details}
+                    onChange={(e) => updateEducation(index, 'details', e.target.value)}
+                    className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+          <button onClick={addEducation} className="w-full mt-1 p-2 bg-black text-white rounded hover:bg-gray-800">+ Add Education</button>
+        </div>
+      </FormSection>
       
-      <FormSection title="Experience">
+      <FormSection
+        titleNode={(
+          <div className="grid grid-cols-1 gap-1">
+            <label className="text-sm font-medium text-gray-700">{`Experience Section Heading`}</label>
+            <input
+              type="text"
+              value={data.headings.experience}
+              onChange={(e) => handleHeadingChange('experience', e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
+            />
+          </div>
+        )}
+      >
         <div className="space-y-4">
           {data.experience.map((exp, index) => (
             <div key={index} className="bg-gray-50 border rounded-md p-3 relative">
@@ -168,7 +407,65 @@ export const ResumeForm = ({ data, setData }: { data: ResumeData, setData: React
         </div>
       </FormSection>
 
-      <FormSection title="Projects">
+      <FormSection
+        titleNode={(
+          <div className="grid grid-cols-1 gap-1">
+            <label className="text-sm font-medium text-gray-700">{`Research Section Heading`}</label>
+            <input
+              type="text"
+              value={data.headings.research}
+              onChange={(e) => handleHeadingChange('research', e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
+            />
+          </div>
+        )}
+      >
+        <div className="space-y-4">
+          {data.research.map((res, rIndex) => (
+            <div key={rIndex} className="bg-gray-50 border rounded-md p-3 relative">
+              <button onClick={() => removeResearch(rIndex)} aria-label="Remove research" className="absolute -top-3 -right-3 text-white bg-red-500 rounded-full h-7 w-7 flex items-center justify-center shadow">×</button>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <Input label="Research Title" name={`research[${rIndex}].title`} value={res.title || ''} onChange={(e) => updateResearch(rIndex, 'title', e.target.value)} />
+                <Input label="Subtitle" name={`research[${rIndex}].subtitle`} value={res.subtitle || ''} onChange={(e) => updateResearch(rIndex, 'subtitle', e.target.value)} />
+                <Input label="Journal / Conference" name={`research[${rIndex}].journal`} value={res.journal || ''} onChange={(e) => updateResearch(rIndex, 'journal', e.target.value)} />
+              </div>
+              <div className="mt-3">
+                <label className="text-sm font-medium text-gray-700">Research Points</label>
+                <div className="space-y-2 mt-2">
+                  {(res.points || []).map((point, pIndex) => (
+                    <div key={pIndex} className="flex items-start gap-2">
+                      <span className="mt-2 text-gray-500">•</span>
+                      <textarea
+                        value={point}
+                        onChange={(e) => updateResearchPoint(rIndex, pIndex, e.target.value)}
+                        rows={2}
+                        className="flex-grow block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
+                      />
+                      <button onClick={() => removeResearchPoint(rIndex, pIndex)} className="text-red-500 font-bold text-xl leading-none">－</button>
+                    </div>
+                  ))}
+                  <button onClick={() => addResearchPoint(rIndex)} className="text-sm text-gray-700 hover:text-black">+ Add point</button>
+                </div>
+              </div>
+            </div>
+          ))}
+          <button onClick={addResearch} className="w-full mt-1 p-2 bg-black text-white rounded hover:bg-gray-800">+ Add Research</button>
+        </div>
+      </FormSection>
+
+      <FormSection
+        titleNode={(
+          <div className="grid grid-cols-1 gap-1">
+            <label className="text-sm font-medium text-gray-700">{`Projects Section Heading`}</label>
+            <input
+              type="text"
+              value={data.headings.projects}
+              onChange={(e) => handleHeadingChange('projects', e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
+            />
+          </div>
+        )}
+      >
         <div className="space-y-4">
           {data.projects.map((proj, index) => (
             <div key={index} className="bg-gray-50 border rounded-md p-3 relative">
@@ -199,6 +496,39 @@ export const ResumeForm = ({ data, setData }: { data: ResumeData, setData: React
             </div>
           ))}
           <button onClick={() => addArrayItem('projects')} className="w-full mt-1 p-2 bg-black text-white rounded hover:bg-gray-800">+ Add Project</button>
+        </div>
+      </FormSection>
+
+      {/* Positions of Responsibility */}
+      <FormSection
+        titleNode={(
+          <div className="grid grid-cols-1 gap-1">
+            <label className="text-sm font-medium text-gray-700">{`Positions of Responsibility Section Heading`}</label>
+            <input
+              type="text"
+              value={data.headings.positions}
+              onChange={(e) => handleHeadingChange('positions', e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
+            />
+          </div>
+        )}
+      >
+        <div className="space-y-4">
+          {data.positions.map((pos, index) => (
+            <div key={index} className="bg-gray-50 border rounded-md p-3 relative">
+              <button onClick={() => removePosition(index)} aria-label="Remove position" className="absolute -top-3 -right-3 text-white bg-red-500 rounded-full h-7 w-7 flex items-center justify-center shadow">×</button>
+              <div className="grid grid-cols-1 gap-1">
+                <label className="text-sm font-medium text-gray-700">Position</label>
+                <input
+                  type="text"
+                  value={pos}
+                  onChange={(e) => updatePosition(index, e.target.value)}
+                  className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
+                />
+              </div>
+            </div>
+          ))}
+          <button onClick={addPosition} className="w-full mt-1 p-2 bg-black text-white rounded hover:bg-gray-800">+ Add Position</button>
         </div>
       </FormSection>
     </div>

--- a/components/templates/HarvardTemplate.tsx
+++ b/components/templates/HarvardTemplate.tsx
@@ -11,37 +11,53 @@ const Section = ({ title, children }: { title: string; children: React.ReactNode
 );
 
 export const HarvardTemplate = ({ data }: { data: ResumeData }) => {
-  const { name, contact, education, experience, projects, research, skills, certifications, positions } = data;
+  const { name, contact, education, experience, projects, research, skills, certifications, positions, headings } = data;
 
   return (
     <div className="resume-page">
       <div className="p-[0.5in] font-[Times] text-[10pt] leading-[1.3]">
-        <header className="text-center mb-[8pt]">
-          <h1 className="text-[18pt] font-bold mb-[2pt]">{name}</h1>
-          <div className="flex justify-center items-center flex-wrap gap-x-[6pt] text-[9pt]">
-            <a href={`tel:${contact.phone}`} className="text-blue-700 hover:underline">{contact.phone}</a>
-            <span>|</span>
-            <a href={`mailto:${contact.email}`} className="text-blue-700 hover:underline">{contact.email}</a>
-            <span>|</span>
-            <a href={contact.linkedin} target="_blank" rel="noopener noreferrer" className="text-blue-700 hover:underline">LinkedIn</a>
-            <span>|</span>
-            <a href={contact.github} target="_blank" rel="noopener noreferrer" className="text-blue-700 hover:underline">GitHub</a>
-            {contact.website && (<><span>|</span><a href={contact.website} target="_blank" rel="noopener noreferrer" className="text-blue-700 hover:underline">Website</a></>)}
-          </div>
-        </header>
+          <header className={`text-center mb-[8pt]`}>
+            <h1 className="text-[18pt] font-bold mb-[2pt]">{name}</h1>
+            <div className="flex justify-center items-center flex-wrap gap-x-[6pt] text-[9pt]">
+              {[
+                contact.phone && <a key="phone" href={`tel:${contact.phone}`} className="text-blue-700 hover:underline">{contact.phone}</a>,
+                contact.email && <a key="email" href={`mailto:${contact.email}`} className="text-blue-700 hover:underline">{contact.email}</a>,
+                contact.linkedin && <a key="linkedin" href={contact.linkedin} target="_blank" rel="noopener noreferrer" className="text-blue-700 hover:underline">LinkedIn</a>,
+                contact.github && <a key="github" href={contact.github} target="_blank" rel="noopener noreferrer" className="text-blue-700 hover:underline">GitHub</a>,
+                contact.website && <a key="website" href={contact.website} target="_blank" rel="noopener noreferrer" className="text-blue-700 hover:underline">Website</a>,
+              ].filter(Boolean).map((el, idx, arr) => (
+                <React.Fragment key={idx}>
+                  {el}
+                  {idx < arr.length - 1 && <span>|</span>}
+                </React.Fragment>
+              ))}
+            </div>
+          </header>
 
-        <Section title="Education">
+        {education && education.length > 0 && (
+        <Section title={headings.education}>
           <div className="flex justify-between items-start">
-            <h3 className="font-bold">{education.degree}</h3>
-            <p>{education.university}</p>
+            {/* Render first item prominently */}
+            <h3 className="font-bold">{education[0].degree}</h3>
+            <p>{education[0].university}</p>
           </div>
-          <p className="mt-[2pt]">{education.details}</p>
+          <p className="mt-[2pt]">{education[0].details}</p>
+          {education.slice(1).map((edu, i) => (
+            <div key={i} className="mt-[6pt]">
+              <div className="flex justify-between items-start">
+                <h3 className="font-bold">{edu.degree}</h3>
+                <p>{edu.university}</p>
+              </div>
+              <p className="mt-[2pt]">{edu.details}</p>
+            </div>
+          ))}
         </Section>
+        )}
 
         {experience && experience.length > 0 && (
-          <Section title="Experience">
+          <Section title={headings.experience}>
             {experience.map((exp, i) => (
-              <div key={i} className="mb-[6pt] last:mb-0">
+              <div key={i} className={`mb-[6pt] last:mb-0`}>
                 <div className="flex justify-between items-baseline">
                   <h3 className="font-bold">{exp.title}</h3>
                   <p className="font-bold">{exp.company}</p>
@@ -59,9 +75,9 @@ export const HarvardTemplate = ({ data }: { data: ResumeData }) => {
         )}
 
         {projects && projects.length > 0 && (
-          <Section title="Projects">
+          <Section title={headings.projects}>
             {projects.map((proj, i) => (
-              <div key={i} className="mb-[6pt] last:mb-0">
+              <div key={i} className={`mb-[6pt] last:mb-0`}>
                 <div className="flex justify-between items-baseline">
                   <h3 className="font-bold">{proj.title}</h3>
                   {proj.link && <a href={proj.link} target="_blank" rel="noopener noreferrer" className="text-[9pt] text-blue-700 hover:underline font-medium">GitHub</a>}
@@ -75,21 +91,24 @@ export const HarvardTemplate = ({ data }: { data: ResumeData }) => {
           </Section>
         )}
 
-        {research && research.points && research.points.length > 0 && (
-          <Section title="Research">
-            <div className="mb-[4pt]">
-              <h3 className="font-bold">{research.title}</h3>
-              <p className="italic my-[2pt]">{research.subtitle}</p>
-              <p className="mb-[2pt]">{research.journal}</p>
-              <ul className="list-disc list-outside ml-4 space-y-[2pt]">
-                {research.points.map((point, j) => <li key={j}>{point}</li>)}
-              </ul>
-            </div>
+        {research && research.length > 0 && (
+          <Section title={headings.research}>
+            {research.map((res, i) => (
+              <div key={i} className="mb-[6pt] last:mb-0">
+                <h3 className="font-bold">{res.title}</h3>
+                <p className="italic my-[2pt]">{res.subtitle}</p>
+                <p className="mb-[2pt]">{res.journal}</p>
+                <ul className={`list-disc list-outside ml-4 space-y-[2pt]`}>
+                  {(res.points || []).map((point, j) => <li key={j}>{point}</li>)}
+                </ul>
+              </div>
+            ))}
           </Section>
         )}
 
-        <Section title="Technical Skills">
-          <div className="space-y-[2pt]">
+        {skills && skills.length > 0 && (
+        <Section title={headings.skills}>
+          <div className={`space-y-[2pt]`}>
             {skills.map((skill, i) => (
               <div key={i}>
                 <span className="font-bold">{skill.category}: </span>
@@ -98,16 +117,17 @@ export const HarvardTemplate = ({ data }: { data: ResumeData }) => {
             ))}
           </div>
         </Section>
+        )}
 
         {certifications && certifications.length > 0 && (
-          <Section title="Certifications">
+          <Section title={headings.certifications}>
             <p>{certifications.join('; ')}</p>
           </Section>
         )}
 
         {positions && positions.length > 0 && (
-          <Section title="Positions of Responsibility">
-            <ul className="list-disc list-outside ml-4 space-y-[2pt]">
+          <Section title={headings.positions}>
+            <ul className={`list-disc list-outside ml-4 space-y-[2pt]`}>
               {positions.map((pos, i) => <li key={i}>{pos}</li>)}
             </ul>
           </Section>

--- a/lib/initialData.ts
+++ b/lib/initialData.ts
@@ -20,11 +20,24 @@ export const initialData = {
     website: "https://example.com",
     leetcode: "https://leetcode.com/johndoe",
   },
-  education: {
-    degree: "B.S. in Computer Science",
-    university: "Example University",
-    details: "Expected Graduation: 2026 • GPA: 3.5/4.0",
+  // Headings are fully renamable in the editor
+  headings: {
+    personal: "Personal Details",
+    education: "Education",
+    experience: "Experience",
+    projects: "Projects",
+    research: "Research",
+    skills: "Technical Skills",
+    certifications: "Certifications",
+    positions: "Positions of Responsibility",
   },
+  education: [
+    {
+      degree: "B.S. in Computer Science",
+      university: "Example University",
+      details: "Expected Graduation: 2026 • GPA: 3.5/4.0",
+    },
+  ],
   experience: [
     {
       title: "Software Engineering Intern",
@@ -48,15 +61,17 @@ export const initialData = {
       ],
     },
   ] as Entry[],
-  research: {
-    title: "Example Research",
-    subtitle: "A short placeholder description of research work",
-    journal: "Presented at Example Conference",
-    points: [
-      "Summary point 1 about the research.",
-      "Summary point 2 about methods or findings.",
-    ],
-  },
+  research: [
+    {
+      title: "Example Research",
+      subtitle: "A short placeholder description of research work",
+      journal: "Presented at Example Conference",
+      points: [
+        "Summary point 1 about the research.",
+        "Summary point 2 about methods or findings.",
+      ],
+    },
+  ],
   skills: [
     { category: "Languages", list: "JavaScript, TypeScript, Python" },
     { category: "Frameworks", list: "React, Next.js, Node.js" },


### PR DESCRIPTION
#3 

- Updated ResumeForm to allow customizable section headings for personal details, education, experience, research, projects, and positions of responsibility.
- Refactored HarvardTemplate to utilize dynamic headings from the resume data.
- Modified initialData structure to support arrays for education and research, enabling multiple entries.
- Improved input handling and UI for contact fields, education, research, and positions of responsibility.

<img width="761" height="440" alt="image" src="https://github.com/user-attachments/assets/c53208c5-86d0-43f2-92b4-bf88d3a657c7" />
