### PR TITLE
fix: update type assertions for dynamic nested key assignments 

### DIFF
--- a/components/ResumeForm.tsx
+++ b/components/ResumeForm.tsx
@@ -45,7 +45,7 @@ export const ResumeForm = ({ data, setData }: { data: ResumeData, setData: React
       setData(prevData => ({
         ...prevData,
         [outerKey]: {
-          // @ts-ignore
+          // @ts-expect-error - dynamic nested key assignment;
           ...prevData[outerKey],
           [innerKey]: value,
         },
@@ -135,7 +135,7 @@ export const ResumeForm = ({ data, setData }: { data: ResumeData, setData: React
   const updateEducation = (index: number, field: 'degree' | 'university' | 'details', value: string) => {
     setData(prev => {
       const next = [...prev.education];
-      next[index] = { ...next[index], [field]: value } as any;
+      next[index] = { ...next[index], [field]: value } as ResumeData['education'][number];
       return { ...prev, education: next };
     });
   };
@@ -156,7 +156,7 @@ export const ResumeForm = ({ data, setData }: { data: ResumeData, setData: React
   const updateResearch = (index: number, field: 'title' | 'subtitle' | 'journal', value: string) => {
     setData(prev => {
       const next = [...prev.research];
-      next[index] = { ...next[index], [field]: value } as any;
+      next[index] = { ...next[index], [field]: value } as ResumeData['research'][number];
       return { ...prev, research: next };
     });
   };
@@ -165,7 +165,7 @@ export const ResumeForm = ({ data, setData }: { data: ResumeData, setData: React
       const next = [...prev.research];
       const points = [...(next[rIndex].points || [])];
       points[pIndex] = value;
-      next[rIndex] = { ...next[rIndex], points } as any;
+      next[rIndex] = { ...next[rIndex], points } as ResumeData['research'][number];
       return { ...prev, research: next };
     });
   };
@@ -173,7 +173,7 @@ export const ResumeForm = ({ data, setData }: { data: ResumeData, setData: React
     setData(prev => {
       const next = [...prev.research];
       const points = [...(next[rIndex].points || []), ''];
-      next[rIndex] = { ...next[rIndex], points } as any;
+      next[rIndex] = { ...next[rIndex], points } as ResumeData['research'][number];
       return { ...prev, research: next };
     });
   };
@@ -181,7 +181,7 @@ export const ResumeForm = ({ data, setData }: { data: ResumeData, setData: React
     setData(prev => {
       const next = [...prev.research];
       const points = (next[rIndex].points || []).filter((_, i) => i !== pIndex);
-      next[rIndex] = { ...next[rIndex], points } as any;
+      next[rIndex] = { ...next[rIndex], points } as ResumeData['research'][number];
       return { ...prev, research: next };
     });
   };


### PR DESCRIPTION

This pull request improves type safety in the `ResumeForm` component by replacing broad `any` type assertions with more specific type annotations tied to the `ResumeData` type. It also clarifies an existing TypeScript error suppression comment.

Type safety improvements:

* Replaced `as any` assertions with `as ResumeData['education'][number]` and `as ResumeData['research'][number]` in the `updateEducation`, `updateResearch`, and related research point update functions to ensure updates conform to the expected data structure. [[1]](diffhunk://#diff-f79e3142b07ce3e21a74b479cedadeb57fe9bbb7d05fa5a5d99f55f78471ba3cL138-R138) [[2]](diffhunk://#diff-f79e3142b07ce3e21a74b479cedadeb57fe9bbb7d05fa5a5d99f55f78471ba3cL159-R159) [[3]](diffhunk://#diff-f79e3142b07ce3e21a74b479cedadeb57fe9bbb7d05fa5a5d99f55f78471ba3cL168-R184)

TypeScript comment clarification:

* Updated a `// @ts-ignore` comment to `// @ts-expect-error - dynamic nested key assignment;` to clarify the reason for suppressing the TypeScript error when dynamically assigning nested keys.